### PR TITLE
Fix PyPI package README

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+0.2.2-post1
+-----------
+
+Fixed bug in ``setup.cfg`` that made README not show up on PyPI.
+
 0.2.2
 -----
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,12 @@ classifiers =
     Topic :: System :: Filesystems
 description = Dropbox support for pyfilesystem2
 license = MIT
-long_description = file: README.rst HISTORY.rst
+long_description = file: README.rst, HISTORY.rst
 name = fs.dropboxfs
 packages = find:
 platforms = any
 url = http://pypi.python.org/pypi/fs.dropboxfs/
-version = 0.2.2
+version = 0.2.2-post1
 
 [options]
 install_requires =


### PR DESCRIPTION
`long_description` was missing a comma, so `setuptools` couldn't find  the README file for PyPI to use.