### PR TITLE
Fix borked `packages` directive in setup.cfg

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+0.2.2-post2
+
+Fixed installation problem. Closes `#6 <https://github.com/PyFilesystem/fs.dropboxfs/issues/6>`_.
+
 0.2.2-post1
 -----------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,17 +22,17 @@ description = Dropbox support for pyfilesystem2
 license = MIT
 long_description = file: README.rst, HISTORY.rst
 name = fs.dropboxfs
-packages = find:
 platforms = any
 url = http://pypi.python.org/pypi/fs.dropboxfs/
-version = 0.2.2-post1
+version = 0.2.2-post2
 
 [options]
 install_requires =
     dropbox>=8.0, <10
     fs>=2.0.26,<2.5
     six>=1.9
-python_requires = >=2.7.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+packages = find:
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 tests_require =
     pytest==4.3.1
     pytest-randomly==1.2.3  ; python_version<="3.4"


### PR DESCRIPTION
See detailed discussion [here](https://github.com/PyFilesystem/pyfilesystem2/issues/345) about the red herring that led to this realization.

TL;DR: I put the `packages = find:` directive in the wrong section, making Python unable to find the source code.